### PR TITLE
ajout de NOTES.txt et de helm test

### DIFF
--- a/charts/postgres/templates/NOTES.txt
+++ b/charts/postgres/templates/NOTES.txt
@@ -1,15 +1,37 @@
-1. Get the application URL by running these commands:
+** Please be patient while the chart is being deployed **
+
+PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:
+
+    {{ template "postgres.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local - Read/Write connection
+
+To connect to your database run the following command:
+
+    kubectl run {{ template "postgres.fullname" . }}-client --rm --tty -i --restart=Never --namespace {{ .Release.Namespace }} --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --env="PGPASSWORD=$POSTGRES_PASSWORD" {{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
+   --labels="{{ template "postgres.fullname" . }}-client=true" {{- end }} --command -- psql --host {{ template "postgres.fullname" . }} -U {{ .Values.postgres.postgresUser }} -d {{- if .Values.postgres.postgresqlDatabase }} {{ .Values.postgres.postgresqlDatabase }}{{- else }} postgres{{- end }} -p 5432
+
+{{ if and (.Values.networkPolicy.enabled)  }}
+Note: Since NetworkPolicy is enabled, only pods with label {{ template "postgres.fullname" . }}-client=true" will be able to connect to this PostgreSQL cluster.
+{{- end }}
+
+To connect to your database from outside the cluster execute the following commands:
+
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "postgres.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "postgres.fullname" . }})
+    {{ if (include "postgres.password" . )  }}PGPASSWORD="$POSTGRES_PASSWORD" {{ end }}psql --host $NODE_IP --port $NODE_PORT -U {{ .Values.postgresqlUsername }} -d {{- if .Values.postgresqlDatabase }} {{ .Values.postgresqlDatabase }}{{- else }} postgres{{- end }}
+
 {{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "postgres.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "postgres.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "postgresql.fullname" . }}'
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "postgres.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    {{ if (.Values.postgres.postgresPassword) }}PGPASSWORD="$POSTGRES_PASSWORD" {{ end }}psql --host $SERVICE_IP --port 5432 -U {{ .Values.postgresqlUsername }} -d {{- if .Values.postgres.postgresDatabase }} {{ .Values.postgresDatabase }}{{- else }} postgres{{- end }}
+
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "postgres.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 5432:5432
+
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "postgres.fullname" . }} 5432:5432 &
+    {{ if (.Values.postgres.postgresPassword) }}PGPASSWORD="$POSTGRES_PASSWORD" {{ end }}psql --host 127.0.0.1 -U {{ .Values.postgresqlUsername }} -d {{- if .Values.postgresqlDatabase }} {{ .Values.postgresqlDatabase }}{{- else }} postgres{{- end }} -p 5432
+
 {{- end }}

--- a/charts/postgres/templates/tests/test-connection.yaml
+++ b/charts/postgres/templates/tests/test-connection.yaml
@@ -5,11 +5,13 @@ metadata:
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
 spec:
   containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "postgres.fullname" . }}:{{ .Values.service.port }}']
+    - name: select
+      image:  {{ .Values.image.repository }}:{{ .Values.image.tag }}
+      env:
+        - name: PGPASSWORD
+          value: {{ .Values.postgres.postgresPassword | quote }}
+      command: ["psql", "-h", {{ include "postgres.fullname" . | quote }}, "-U", {{ .Values.postgres.postgresUser | quote }}, "-d", {{ .Values.postgres.postgresDatabase | quote }}, "-c", "SELECT 1"]
   restartPolicy: Never


### PR DESCRIPTION
Normalement en console s'affiche des commandes qui marchent.
helm test RELEASE-NAME fonctionne (au bout d'un certain temps par contre est-ce lié à la readiness?)

on peut lancer avec et sans network security les commandes se mettent à jour par contre un test rapide semble invalidé que le network policy soit efficace.

A voir mais dans values il faudrait peut etre remonté d'un cran postgres.postgresUser a postgresUser