### PR TITLE
[onyxia] Use 8080 as default ui port

### DIFF
--- a/charts/onyxia/Chart.yaml
+++ b/charts/onyxia/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.0
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/onyxia/values.yaml
+++ b/charts/onyxia/values.yaml
@@ -45,7 +45,7 @@ ui:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
-  containerPort: 80
+  containerPort: 8080
   service:
     type: ClusterIP
     port: 80


### PR DESCRIPTION
Requires onyxia-ui >= 0.23.0 (2021-11-27).

It was 80 before (see https://github.com/InseeFrLab/onyxia-web/pull/273)

Signed-off-by: Mathieu Parent <mathieu.parent@insee.fr>