### PR TITLE
onyxia: add OpenShift route support

### DIFF
--- a/charts/onyxia/Chart.yaml
+++ b/charts/onyxia/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.5.2
+version: 3.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/onyxia/templates/route-api.yaml
+++ b/charts/onyxia/templates/route-api.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.route.enabled -}}
+{{- $fullNameApi := include "onyxia.api.fullname" . -}}
+{{- $fullName := include "onyxia.fullname" . -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}-api
+  labels:
+    {{- include "onyxia.labels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.route.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  host: {{ .Values.route.host | quote }}
+  path: /api
+  to:
+    kind: Service
+    name: {{ $fullNameApi }}
+  tls:
+    termination: {{ .Values.route.tls.termination }}
+    {{- if .Values.route.tls.key }}
+    key: {{- .Values.route.tls.key }}
+    {{- end }}
+    {{- if .Values.route.tls.certificate }}
+    certificate: {{- .Values.route.tls.certificate }}
+    {{- end }}
+    {{- if .Values.route.tls.caCertificate }}
+    caCertificate: {{- .Values.route.tls.caCertificate }}
+    {{- end }}
+    {{- if .Values.route.tls.destinationCACertificate }}
+    destinationCACertificate: {{- .Values.route.tls.destinationCACertificate }}
+    {{- end }}
+  wildcardPolicy: {{ .Values.route.wildcardPolicy }}
+{{- end }}

--- a/charts/onyxia/templates/route-ui.yaml
+++ b/charts/onyxia/templates/route-ui.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.route.enabled -}}
+{{- $fullNameUi := include "onyxia.ui.fullname" . -}}
+{{- $fullName := include "onyxia.fullname" . -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}-ui
+  labels:
+    {{- include "onyxia.labels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.route.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  host: {{ .Values.route.host | quote }}
+  path: /
+  to:
+    kind: Service
+    name: {{ $fullNameUi }}
+  tls:
+    termination: {{ .Values.route.tls.termination }}
+    {{- if .Values.route.tls.key }}
+    key: {{- .Values.route.tls.key }}
+    {{- end }}
+    {{- if .Values.route.tls.certificate }}
+    certificate: {{- .Values.route.tls.certificate }}
+    {{- end }}
+    {{- if .Values.route.tls.caCertificate }}
+    caCertificate: {{- .Values.route.tls.caCertificate }}
+    {{- end }}
+    {{- if .Values.route.tls.destinationCACertificate }}
+    destinationCACertificate: {{- .Values.route.tls.destinationCACertificate }}
+    {{- end }}
+  wildcardPolicy: {{ .Values.route.wildcardPolicy }}
+{{- end }}

--- a/charts/onyxia/values.yaml
+++ b/charts/onyxia/values.yaml
@@ -28,6 +28,20 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  
+route:
+  enabled: false
+  annotations:
+    {}
+    # route.openshift.io/termination: "reencrypt"
+  host: chart-example.local
+  tls:
+    termination: edge
+    # key:
+    # certificate:
+    # caCertificate:
+    # destinationCACertificate:
+  wildcardPolicy: None
 
 ui:
   name: ui


### PR DESCRIPTION
It provides configuration of OpenShift routes for Onyxia as an alternative to Kubernetes Ingress.