### PR TITLE
s3-operator : removal of a comment that causes Helm templating to fail

### DIFF
--- a/charts/s3-operator/Chart.yaml
+++ b/charts/s3-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.1"
+appVersion: "0.1.2"

--- a/charts/s3-operator/Chart.yaml
+++ b/charts/s3-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.1.1"

--- a/charts/s3-operator/templates/deployment.yaml
+++ b/charts/s3-operator/templates/deployment.yaml
@@ -33,7 +33,6 @@ spec:
         kubectl.kubernetes.io/default-container: manager
     spec:
       containers:
-      #- args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080

--- a/charts/s3-operator/values.yaml
+++ b/charts/s3-operator/values.yaml
@@ -1,3 +1,9 @@
+crds:
+  # -- Install and upgrade CRDs
+  install: true
+  # -- Keep CRDs on chart uninstall
+  keep: true
+  
 controllerManager:
   manager:
     containerSecurityContext:


### PR DESCRIPTION
The removed 

```yaml
- args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
```

line caused the templated Deployment to look like this : 

```yaml
    spec:
      containers:
      #- args:
        null
      - args:
        - --health-probe-bind-address=:8081
        # - ...
```

which then prevented Helm from installing the chart.

