### PR TITLE
s3-operator : add existingSecret pattern to manage S3 auth

### DIFF
--- a/charts/s3-operator/templates/deployment.yaml
+++ b/charts/s3-operator/templates/deployment.yaml
@@ -38,8 +38,6 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --s3-endpoint-url={{ .Values.s3.endpointUrl }}
-        - --s3-access-key={{ .Values.s3.accessKey }}
-        - --s3-secret-key={{ .Values.s3.secretKey }}  
         {{- if .Values.s3.caCertificateBundlePath }}
         - --s3-ca-certificate-bundle-path={{ .Values.s3.caCertificateBundlePath }}
         {{- end }}
@@ -51,7 +49,26 @@ spec:
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
+        - name: S3_ACCESS_KEY
+          {{- if .Values.s3.existingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.s3.existingSecret }}
+              key: S3_ACCESS_KEY
+          {{- else }}
+          value: {{ .Values.s3.accessKey }}
+          {{- end }}
+        - name: S3_SECRET_KEY
+          {{- if .Values.s3.existingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.s3.existingSecret }}
+              key: S3_SECRET_KEY
+          {{- else }}
+          value: {{ .Values.s3.secretKey }}
+          {{- end }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.controllerManager.manager.imagePullPolicy | default "IfNotPresent" | quote }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/s3-operator/values.yaml
+++ b/charts/s3-operator/values.yaml
@@ -14,6 +14,7 @@ controllerManager:
     image:
       repository: inseefrlab/s3-operator
       tag: latest
+    imagePullPolicy: IfNotPresent
     resources:
       limits:
         cpu: 1000m
@@ -25,8 +26,17 @@ controllerManager:
 kubernetesClusterDomain: cluster.local
 s3:
   endpointUrl: "localhost:9000"
-  accessKey: ""
-  secretKey: ""
+
+  # To manage access/secret keys, two options : 
+  #   - (Poor) Directly set them using the accessKey/secretKey parameters below.
+  #   This makes them directly visible to anyone with enough rights on your k8s.
+  #   - (Better) Use the existingSecret parameter to reference a k8s secret, which
+  #   needs to contain at least two environment variables : S3_ACCESS_KEY and S3_SECRET_KEY.
+  #   This in turn allows you to use another mechanism to further protect these, 
+  #   eg sealed secrets.
+  existingSecret: "my-s3-operator-auth-secret"
+  # accessKey: ""
+  # secretKey: ""
 
   # If both "caCertificate" parameters are present, only
   # caCertificatesBase64 is used.


### PR DESCRIPTION
The naive, first implementation pushed for s3-operator chart only allowed to set the S3 access key and secret key directly in the `values.yaml` file, which basically makes them readable by anyone with rights on the kubernetes cluster.

This PR adds the "existing secret" pattern, which allows referencing a secret instead of defining the keys directly. While a k8s secret by itself is not terribly secure, it allows using other tools like Sealed Secrets to further protect these keys.

Totally unrelated to this, the PR also adds an `imagePullPolicy` parameter to the deployment template and `values.yaml` file, as we needed it to force the pull of inseefrlab/s3-operator while testing.