### PR TITLE
switched to `repository` and `tag` for standard renovate matching

### DIFF
--- a/charts/onyxia/Chart.yaml
+++ b/charts/onyxia/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.9.0
+version: 4.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/onyxia/Chart.yaml
+++ b/charts/onyxia/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.8.4
+version: 3.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/onyxia/templates/deployment-api.yaml
+++ b/charts/onyxia/templates/deployment-api.yaml
@@ -34,7 +34,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.api.securityContext | nindent 12 }}
-          image: "{{ .Values.api.image.name }}:{{ .Values.api.image.version }}"
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           envFrom:
             - configMapRef:
                 name: {{ template "onyxia.fullname" . }}

--- a/charts/onyxia/templates/deployment-ui.yaml
+++ b/charts/onyxia/templates/deployment-ui.yaml
@@ -28,7 +28,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.ui.securityContext | nindent 12 }}
-          image: "{{ .Values.ui.image.name }}:{{ .Values.ui.image.version }}"
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           env:
            {{- if .Values.ui.env }}

--- a/charts/onyxia/values.yaml
+++ b/charts/onyxia/values.yaml
@@ -48,8 +48,8 @@ ui:
   name: ui
   replicaCount: 1
   image:
-    name: inseefrlab/onyxia-web
-    version: 2.13.53
+    repository: inseefrlab/onyxia-web
+    tag: 2.13.53
     pullPolicy: IfNotPresent
   podLabels: {}
   podSecurityContext:
@@ -90,8 +90,8 @@ api:
   name: api
   replicaCount: 1
   image:
-    name: inseefrlab/onyxia-api
-    version: v0.27
+    repository: inseefrlab/onyxia-api
+    tag: v0.27
     pullPolicy: IfNotPresent
   contextPath: /api
   podLabels: {}


### PR DESCRIPTION
changes in Onyxia/values.yaml :
- `ui:image:name` is now `ui:image:repository`
- `ui:image:version` is now `ui:image:tag`

templates also changed (see files diff)
