### PR TITLE
chore: update s3-operator image tag

### DIFF
--- a/charts/s3-operator/Chart.yaml
+++ b/charts/s3-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.3"
+appVersion: "v0.3.0"

--- a/charts/s3-operator/values.yaml
+++ b/charts/s3-operator/values.yaml
@@ -13,7 +13,7 @@ controllerManager:
         - ALL
     image:
       repository: inseefrlab/s3-operator
-      tag: latest
+      tag: v0.3.0
     imagePullPolicy: IfNotPresent
     resources:
       limits:


### PR DESCRIPTION
Replaces `latest` tag for s3-operator Docker image to use the latest (as of today) version available, `v0.3.0`