### PR TITLE
Allow using existing cluster role

### DIFF
--- a/charts/onyxia/Chart.yaml
+++ b/charts/onyxia/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.0.1
+version: 4.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/onyxia/templates/cluster-role-binding.yaml
+++ b/charts/onyxia/templates/cluster-role-binding.yaml
@@ -9,7 +9,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ default "cluster-admin" .Values.serviceAccount.existingClusterRole }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "onyxia.api.serviceAccountName" . }}

--- a/charts/onyxia/values.yaml
+++ b/charts/onyxia/values.yaml
@@ -10,7 +10,7 @@ serviceAccount:
   create: true
   # If true, the created service account is bound to a ClusterRole (default : cluster-admin) ;
   # if false, it is instead bound to the admin Role, and thus scoped to the namespace
-  clusterAdmin: true 
+  clusterAdmin: false 
   # Existing ClusterRole to use for the CRB if clusterAdmin is set to true
   # existingClusterRole: "" 
   # Annotations to add to the service account

--- a/charts/onyxia/values.yaml
+++ b/charts/onyxia/values.yaml
@@ -8,7 +8,11 @@ hostAliases: []
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
-  clusterAdmin: false # If true, give cluster admin permissions. Otherwise, be admin scoped to the namespace
+  # If true, the created service account is bound to a ClusterRole (default : cluster-admin) ;
+  # if false, it is instead bound to the admin Role, and thus scoped to the namespace
+  clusterAdmin: true 
+  # Existing ClusterRole to use for the CRB if clusterAdmin is set to true
+  # existingClusterRole: "" 
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.


### PR DESCRIPTION
We are trying to reduce the rights given to the ServiceAccount used by Onyxia, down from `cluster-admin` to... something. 

In order to better understand this possible target could be, this PR adds a parameter to use a pre-existing ClusterRole as a replacement for `cluster-admin` hard-coded in the chart.

As of the initial commit, this is made in a minimalistic way, with a notable drawback : we keep the existing `clusterAdmin` parameter (which determines whether we use a Role or ClusterRole) as is. Given the aim of this PR, you might prefer a more drastic change, say renaming the `clusterAdmin` parameter to something else, to prevent possible confusion.

If need be, I'll add more commits to this effect if this is deemed useful. Of course, I'm also fine with direct merging as is. 😄 