### PR TITLE
A Kubernetes PriorityClassName can be set for onyxia web and api

### DIFF
--- a/charts/onyxia/templates/deployment-api.yaml
+++ b/charts/onyxia/templates/deployment-api.yaml
@@ -70,4 +70,7 @@ spec:
     {{- end }}
     {{- if .Values.api.extraVolumes }}
       volumes: {{- toYaml .Values.api.extraVolumes | nindent 6 }}
+    {{- end }}    
+    {{- if .Values.api.priorityClassName }}
+    priorityClassName: "{{ .Values.api.priorityClassName }}"
     {{- end }}

--- a/charts/onyxia/templates/deployment-web.yaml
+++ b/charts/onyxia/templates/deployment-web.yaml
@@ -69,3 +69,6 @@ spec:
     {{- if .Values.web.extraVolumes }}
       volumes: {{- toYaml .Values.web.extraVolumes | nindent 6 }}
     {{- end }}
+    {{- if .Values.web.priorityClassName }}
+    priorityClassName: "{{ .Values.web.priorityClassName }}"
+    {{- end }}

--- a/charts/onyxia/values.yaml
+++ b/charts/onyxia/values.yaml
@@ -55,6 +55,12 @@ web:
     repository: inseefrlab/onyxia-web
     tag: 2.28.0
     pullPolicy: IfNotPresent
+
+  ## Pod priority settings
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  priorityClassName: ""
+
   podLabels: {}
   podSecurityContext:
     {}
@@ -97,6 +103,12 @@ api:
     repository: inseefrlab/onyxia-api
     tag: v0.30
     pullPolicy: IfNotPresent
+
+  ## Pod priority settings
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  priorityClassName: ""
+  
   contextPath: /api
   podLabels: {}
   podSecurityContext:


### PR DESCRIPTION
A small piece of code to add a priorityClassName into onyx-web and onyxia-api (useful if you want to prevent the according pods from being deleted by Kubernetes scheduler).
I didn't bump the Chart version. Maybe you want to do this on your own?

Let me know if I miss something.
