### PR TITLE
feat(addok): move data volume in values

### DIFF
--- a/charts/addok/Chart.yaml
+++ b/charts/addok/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/addok/templates/deployment.yaml
+++ b/charts/addok/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
             name: {{ .Release.Name }}-configmap
             items:
               - key: addok.conf
+                path: addok.conf
         {{- toYaml .Values.volumes.dataVolume | nindent 8 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/addok/templates/deployment.yaml
+++ b/charts/addok/templates/deployment.yaml
@@ -21,14 +21,12 @@ spec:
         {{- include "addok.selectorLabels" . | nindent 8 }}
     spec:
       volumes:
-        - name: data
-          emptyDir: {}
         - name: conf
           configMap:
             name: {{ .Release.Name }}-configmap
             items:
               - key: addok.conf
-                path: addok.conf
+        {{- toYaml .Values.volumes.dataVolume | nindent 8 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/addok/templates/redis-deployment.yaml
+++ b/charts/addok/templates/redis-deployment.yaml
@@ -11,8 +11,7 @@ spec:
       labels: {{- include "addok.redis.selectorLabels" . | nindent 8 }}
     spec:
       volumes:
-        - name: data
-          emptyDir: {}
+        {{- toYaml .Values.volumes.dataVolume | nindent 8 }}
       {{- if .Values.redis.init.enabled }}
       initContainers:
         - name: download-data

--- a/charts/addok/values.yaml
+++ b/charts/addok/values.yaml
@@ -145,3 +145,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+volumes:
+  dataVolume:
+  - name: data
+    emptyDir: {}


### PR DESCRIPTION
Bonjour, j'ai un use case où j'aimerai accéder au data de addok depuis un pvc alimenté par un job avec un hook pre-install, j'ai donc déplacé le bloc du volume data dans les values, ça ne modifie en rien le comportement actuel

En esperant que vous pouvez release cette version afin que je puisse utiliser la dépendance sans copier toute la chart