### PR TITLE
feat: allow defined container volumes

### DIFF
--- a/charts/s3-operator/Chart.yaml
+++ b/charts/s3-operator/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.5
+version: 0.5.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/s3-operator/templates/deployment.yaml
+++ b/charts/s3-operator/templates/deployment.yaml
@@ -35,7 +35,11 @@ spec:
       {{- with  .Values.controllerManager.manager.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- end }}  
+      {{- end }}
+      {{- with .Values.controllerManager.manager.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args:
         - --health-probe-bind-address=:8081
@@ -85,6 +89,10 @@ spec:
         {{- end }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.controllerManager.manager.imagePullPolicy | default "IfNotPresent" | quote }}
+        {{- with .Values.controllerManager.manager.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Hello

This PR allows users to configure custom volumes to be mounted in the operator container, this is needed to mount a custom CA from a secret into the container as a file and use it them with the `caCertificateBundlePath` arg instead of using the `caCertificatesBase64` arg.

```
values:
    s3:
      caCertificateBundlePath: "/etc/certificates/ca.crt"
    controllerManager:
      manager:
        volumes:
          - name: custom-ca
             secret:
               secretName: custom-ca-bundle
        volumeMounts:
          - name: custom-ca
             mountPath: /etc/certificates
             readOnly: true
```