### PR TITLE
Shinyproxy : manage proxy.default-websocket-reconnection-mode + Role update

### DIFF
--- a/charts/shinyproxy/Chart.yaml
+++ b/charts/shinyproxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: shinyproxy
-description: A Helm chart to deplo ShinyProxy (https://www.shinyproxy.io/)
+description: A Helm chart to deploy ShinyProxy (https://www.shinyproxy.io/)
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.1
+version: 2.3.0
 
 dependencies:
 - name: library-chart

--- a/charts/shinyproxy/templates/configmap.yaml
+++ b/charts/shinyproxy/templates/configmap.yaml
@@ -32,6 +32,7 @@ data:
       hide-navbar: {{ .Values.proxyConfig.hideNavbar }}
       default-max-instances: {{ .Values.proxyConfig.defaultMaxInstances }}
       default-proxy-max-lifetime: {{ .Values.proxyConfig.defaultProxyMaxLifeTime }}
+      default-webSocket-reconnection-mode: {{ .Values.proxyConfig.defaultWebSocketReconnectionMode }}
       {{ if eq .Values.proxyConfig.authentication.type "openid" }}
       openid:
         auth-url: {{ .Values.proxyConfig.authentication.openid.authURL }}

--- a/charts/shinyproxy/templates/role.yaml
+++ b/charts/shinyproxy/templates/role.yaml
@@ -7,5 +7,5 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]       
-    resources: ["pods/log"]
-    verbs: ["get", "watch"]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]

--- a/charts/shinyproxy/values.yaml
+++ b/charts/shinyproxy/values.yaml
@@ -38,6 +38,7 @@ proxyConfig:
   containerWaitTime: 20000
   defaultMaxInstances: 1
   defaultProxyMaxLifeTime: 120
+  defaultWebSocketReconnectionMode: None
   port: 8080
   authentication:
     type: none


### PR DESCRIPTION
Hello,

This PR is mostly to add proxy-level [`defaultWebSocketReconnectionMode`](https://www.shinyproxy.io/documentation/ui/#automatically-reconnecting-websockets) capability to the chart. This allows for (somewhat) graceful management of the websocket reconnection whenever the ingress controller is reloaded - instead of a grey overlay blocking the app, we can automatically refresh it (using non-default value `Auto` or `Confirm`). This was already possible at app-level, but since we have end-users managing a lot of apps through a single proxy, this default value is beneficial.

Alongside this main change is a modification to the Role tied to the service account running Shinyproxy. With the previous Role, whenever a new app is launched, this warning was logged in the proxy pod : 

```
2025-06-17 10:04:21.939  INFO 1 --- [pool-2-thread-4] e.o.containerproxy.service.ProxyService  : [user=redacted proxyId=32e65263-344a-4006-abed-eb372a7e040b specId=app-hello-world-test] Starting proxy
2025-06-17 10:04:23.924  WARN 1 --- [pool-2-thread-4] e.o.c.b.kubernetes.KubernetesBackend     : Cannot parse events of pod because of insufficient permissions. If fine-grained statistics are desired, give the ShinyProxy ServiceAccount permission to events of pods.
2025-06-17 10:04:24.321  INFO 1 --- [pool-2-thread-4] e.o.containerproxy.service.ProxyService  : [user=redacted proxyId=32e65263-344a-4006-abed-eb372a7e040b specId=app-hello-world-test] Proxy activated
```

I couldn't find clear documentation related to this, only a couple a resources : 

- [This supposedly outdated example of manifest-based deployment](https://github.com/openanalytics/shinyproxy-config-examples/blob/master/03-containerized-kubernetes/README.md#notes-on-the-configuration)
- [The rights used in shinyproxy-operator](https://github.com/openanalytics/shinyproxy-operator/blob/master/docs/deployment/bases/shinyproxy/resources/shinyproxy.rbac.yaml), aka the recommended way to run SP in production. 🙈 

Based on these two pages : 

- It looks like the permissions on the `pods/log` subresource are not needed anymore (I trust the shinyproxy-operator config more than the other page).
- When trying to add "write" permissions to events (`"create", "update", "patch", "delete"`), we had some issues when trying to install the chart so I left them out and only added `"get", "list", "watch"`.
- The capabilities for managing Kubernetes `Services` are unneeded for this helm chart, and left out as well.

For what it's worth, a manual deployment using the Role visible in this PR and some manual tests showed no problems (and obviously the warning motivating this change is gone as well), though this shouldn't be considered proper testing by any stretch.